### PR TITLE
Use flatten_json and Update Table Schemas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pyyaml==6.0.2 
-pandas==2.2.3
+flatten_json==0.1.14


### PR DESCRIPTION
## Description
This PR:
* updates the schemas to account for list and json data
* updates how I append the static configurations to the configuration.json file, since `update` is used by Fivetran
* updates the flattening to use `flatten_json.flatten` instead of `pandas.json_normalize`, since the latter returns a dataframe